### PR TITLE
Added support of different severity levels in the XML report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "nsp-reporter-checkstyle",
   "version": "1.0.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.2.1",
@@ -3749,6 +3748,15 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3774,15 +3782,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -4,6 +4,17 @@ const path = require('path');
 const { format } = require('util');
 const checkstyle = require('checkstyle-formatter');
 
+function cvssScoreToSeverity(score) {
+    if (score < 4.0) {
+        return 'info';
+    } else if (score >= 4.0 && score < 7.0) {
+        return 'warning';
+    } else if (score >= 7.0) {
+        return 'error';
+    }
+    return 'ignore';
+}
+
 module.exports.error = function (error, args) {
     console.error(error.toString());
 };
@@ -15,12 +26,12 @@ module.exports.success = function (result, args) {
 module.exports.check = {
     success(result, args) {
         const messages = result.data.map(function (item) {
-            const { module, title, vulnerable_versions, patched_versions, version, advisory } = item;
+            const { module, title, vulnerable_versions, patched_versions, version, advisory, cvss_score } = item;
 
             return {
                 line: 0,
                 column: 0,
-                severity: 'error',
+                severity: cvssScoreToSeverity(cvss_score),
                 message: format(
                     'Module %s has a known vulnerability: "%s" (vulnerable: %s, patched: %s, yours: %s), see %s',
                     module, title, vulnerable_versions, patched_versions, version, advisory

--- a/test/fixtures/findings.empty.xml
+++ b/test/fixtures/findings.empty.xml
@@ -2,6 +2,7 @@
 <checkstyle version="4.3">
 <file name="/some/absolute/path/package.json">
 <error line="0" column="0" severity="error" message="Module shell-quote has a known vulnerability: &quot;Potential Command Injection&quot; (vulnerable: &lt;=1.6.0, patched: &gt;=1.6.1, yours: 1.6.0), see https://nodesecurity.io/advisories/117" />
-<error line="0" column="0" severity="error" message="Module minimatch has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/118" />
+<error line="0" column="0" severity="warning" message="Module minimatch has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/118" />
+<error line="0" column="0" severity="info" message="Module debug has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/119" />
 </file>
 </checkstyle>

--- a/test/fixtures/findings.json
+++ b/test/fixtures/findings.json
@@ -45,7 +45,7 @@
             "overview": "Minimatch is a minimal matching utility that works by converting glob expressions into JavaScript `RegExp` objects.  The primary function, `minimatch(path, pattern)` is vulnerable to ReDoS in the `pattern` parameter.  This is because of the regular expression on line 521 of minimatch.js: `/((?:\\\\{2})*)(\\\\?)\\|/g,`.  The problematic portion of the regex is `((?:\\\\{2})*)` which matches against `\\\\`.\n\nA proof of concept is as follows:\n```\nvar minimatch = require(“minimatch”);\n\n// utility function for generating long strings\nvar genstr = function (len, chr) {\n  var result = “”;\n  for (i=0; i<=len; i++) {\n    result = result + chr;\n  }\n  return result;\n}\n\nvar exploit = “[!” + genstr(1000000, “\\\\”) + “A”;\n\n// minimatch exploit.\nconsole.log(“starting minimatch”);\nminimatch(“foo”, exploit);\nconsole.log(“finishing minimatch”);\n```",
             "recommendation": "Updated to version 3.0.2 or greater",
             "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "cvss_score": 7.5,
+            "cvss_score": 6.9,
             "module": "minimatch",
             "version": "3.0.0",
             "vulnerable_versions": "<=3.0.1",
@@ -56,7 +56,27 @@
                 "minimatch@3.0.0"
             ],
             "advisory": "https://nodesecurity.io/advisories/118"
+        },
+        {
+            "id": 119,
+            "updated_at": "2016-08-09T14:16:01.000Z",
+            "created_at": "2016-05-25T16:37:20.000Z",
+            "publish_date": "2016-06-20T15:52:52.000Z",
+            "overview": "Minimatch is a minimal matching utility that works by converting glob expressions into JavaScript `RegExp` objects.  The primary function, `minimatch(path, pattern)` is vulnerable to ReDoS in the `pattern` parameter.  This is because of the regular expression on line 521 of minimatch.js: `/((?:\\\\{2})*)(\\\\?)\\|/g,`.  The problematic portion of the regex is `((?:\\\\{2})*)` which matches against `\\\\`.\n\nA proof of concept is as follows:\n```\nvar minimatch = require(“minimatch”);\n\n// utility function for generating long strings\nvar genstr = function (len, chr) {\n  var result = “”;\n  for (i=0; i<=len; i++) {\n    result = result + chr;\n  }\n  return result;\n}\n\nvar exploit = “[!” + genstr(1000000, “\\\\”) + “A”;\n\n// minimatch exploit.\nconsole.log(“starting minimatch”);\nminimatch(“foo”, exploit);\nconsole.log(“finishing minimatch”);\n```",
+            "recommendation": "Updated to version 3.0.2 or greater",
+            "cvss_vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "cvss_score": 3.7,
+            "module": "debug",
+            "version": "3.0.0",
+            "vulnerable_versions": "<=3.0.1",
+            "patched_versions": ">=3.0.2",
+            "title": "Regular Expression Denial of Service",
+            "path": [
+                "nsp-reporter-checkstyle@1.0.0",
+                "debug@3.0.0"
+            ],
+            "advisory": "https://nodesecurity.io/advisories/119"
         }
     ],
-    "message": "2 vulnerabilities found"
+    "message": "3 vulnerabilities found"
 }

--- a/test/fixtures/findings.xml
+++ b/test/fixtures/findings.xml
@@ -2,6 +2,7 @@
 <checkstyle version="4.3">
 <file name="/some/absolute/path/package.json">
 <error line="0" column="0" severity="error" message="Module shell-quote has a known vulnerability: &quot;Potential Command Injection&quot; (vulnerable: &lt;=1.6.0, patched: &gt;=1.6.1, yours: 1.6.0), see https://nodesecurity.io/advisories/117" />
-<error line="0" column="0" severity="error" message="Module minimatch has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/118" />
+<error line="0" column="0" severity="warning" message="Module minimatch has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/118" />
+<error line="0" column="0" severity="info" message="Module debug has a known vulnerability: &quot;Regular Expression Denial of Service&quot; (vulnerable: &lt;=3.0.1, patched: &gt;=3.0.2, yours: 3.0.0), see https://nodesecurity.io/advisories/119" />
 </file>
 </checkstyle>


### PR DESCRIPTION
# New feature

Support for different levels of message severity:
* `error` - when CVSS score is 7.0 and above
* `warning` - when CVSS score is between 4.0 and 7.0
* `info` - when CVSS score is below 4.0

As suggested in this [issue](https://github.com/pigulla/nsp-reporter-checkstyle/issues/2)